### PR TITLE
Fixed Ubuntu install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ To run the development tests with substituted answers from answers.config use th
 ##### Ubuntu
 Unfortunately, aptitude has an old version of erlang which is less than ideal.
 
-First, install all necessary dependencies `apt-get -y install build-essential m4 libncurses5-dev libssh-dev unixodbc-dev `
-<br>`libgmp3-dev libwxgtk2.8-dev libglu1-mesa-dev fop xsltproc default-jdk`
+First, install all necessary dependencies `apt-get -y install build-essential m4 libncurses5-dev libssh-dev unixodbc-dev` `libgmp3-dev libwxgtk2.8-dev libglu1-mesa-dev fop xsltproc default-jdk`
 
 Next, move to some place to install erlang and pull the .tar.gz `wget http://www.erlang.org/download/otp_src_R16B.tar.gz`
 


### PR DESCRIPTION
When you split the Ubuntu install dependencies onto two lines it made it copy and paste into the terminal wrong.  I changed the formatting a little so it can be copied and pasted into the terminal from the README preview but still displays as two lines on github.

-Rob
