### PR TITLE
Correct last test name in boolean expressions test

### DIFF
--- a/test/about_boolean_expressions_test.erl
+++ b/test/about_boolean_expressions_test.erl
@@ -28,6 +28,6 @@ this_applies_to_or_as_well_test() ->
 make_de_morgan_proud_test() ->
   ?assert(about_boolean_expressions:make_de_morgan_proud()).
 
-and_syntax_you_would_not_expect_test() ->
+syntax_you_might_not_expect_test() ->
   ?assert(about_boolean_expressions:syntax_you_might_not_expect()).
 


### PR DESCRIPTION
Last test in boolean expressions koans constantly failed. After renaming it passed.
