### PR TITLE
Flipped comparison on "syntax_you_might_not_expect"

### DIFF
--- a/src/about_boolean_expressions.erl
+++ b/src/about_boolean_expressions.erl
@@ -35,5 +35,5 @@ make_de_morgan_proud() ->
 
 syntax_you_might_not_expect() ->
   Weird = ?ReplaceMe,
-  (Weird =< 3) and (Weird /= 2).
+  (Weird >= 3) and (Weird /= 2).
 


### PR DESCRIPTION
I'm assuming you want the student to set ?ReplaceMe to 'true' or to 'false' to demonstrate that 'true' and 'false' are atoms which compare greater than integers. If that's the case, the first comparison on syntax_you_might_not_expect() is flipped.

false = (Weird =< 3) and (Weird /= 2).
true = (Weird >= 3) and (Weird /= 2).
