### PR TITLE
More consistent ?ReplaceMe in about_boolean_expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To show a hint for the current koan, use `escript koans hint`.
 ### Erlang Installation
 
 ##### OSX
-`brew install erlang` will install erlang via <a href="https://github.com/mxcl/homebrew">homebrew</a>. The current version is R16B. 
+<a href="https://github.com/mxcl/homebrew">Homebrew</a> can be used to install Erlang, but it has an out-of-date version (R15B).  To get the most updated version (R16B), you can tap into the `homebrew/homebrew-versions` repo, and get the `erlang-r16` formula from there.  To do this, run `brew tap homebrew/versions` followed by `brew install erlang-r16`.
 
 ##### Ubuntu
 Unfortunately, aptitude has an old version of erlang which is less than ideal.

--- a/resources/answers.erl
+++ b/resources/answers.erl
@@ -19,7 +19,7 @@ cheat_sheet() ->
         {special_words_evaluate_only_what_is_necessary, false},
         {this_applies_to_or_as_well, true},
         {make_de_morgan_proud, true},
-        {syntax_you_might_not_expect, 3}
+        {syntax_you_might_not_expect, true}
       ]},
     {about_strings, [
         {first_we_must_see_what_lies_underneath, true},

--- a/src/about_boolean_expressions.erl
+++ b/src/about_boolean_expressions.erl
@@ -34,6 +34,5 @@ make_de_morgan_proud() ->
   ((not true) orelse (?ReplaceMe)) =:= (not (false andalso true)).
 
 syntax_you_might_not_expect() ->
-  Weird = ?ReplaceMe,
-  (Weird =< 3) and (Weird /= 2).
+  ?ReplaceMe =:= (1 =< 2) and (3 /= 4).
 


### PR DESCRIPTION
Every koan in `about_boolean_expressions` has either `true` or `false` as the answer, so the weird syntax koan was a bit out-of-place.

Also, I added more detailed instructions for installing from Homebrew because their default version is behind.
