### PR TITLE
Fix spelling homegenious → homogeneous

### DIFF
--- a/resources/answers.erl
+++ b/resources/answers.erl
@@ -60,7 +60,7 @@ cheat_sheet() ->
         {there_also_exists_a_shorthand_for_or, 5}
       ]},
     {about_lists, [
-        {lists_are_not_homogenious, 1},
+        {lists_are_not_homogeneous, 1},
         {we_can_add, [mango, orange]},
         {we_can_also_take_away, apple},
         {lists_define_delete, apple},

--- a/src/about_lists.erl
+++ b/src/about_lists.erl
@@ -1,5 +1,5 @@
 -module(about_lists).
--export([lists_are_not_homogenious/0,
+-export([lists_are_not_homogeneous/0,
          we_can_add/0,
          we_can_also_take_away/0,
          lists_define_delete/0,
@@ -11,7 +11,7 @@
          lists_of_tuples_can_be_found_by_key/0
         ]).
 
-lists_are_not_homogenious() ->
+lists_are_not_homogeneous() ->
     NotJustFruits = [apple, banana, __, mango],
     Element = lists:nth(3, NotJustFruits),
     (Element < 2) and (Element > 0).

--- a/test/about_lists_test.erl
+++ b/test/about_lists_test.erl
@@ -1,8 +1,8 @@
 -module(about_lists_test).
 -include_lib("eunit/include/eunit.hrl").
 
-lists_are_not_homogenious_test() ->
-    ?assert(about_lists:lists_are_not_homogenious()).
+lists_are_not_homogeneous_test() ->
+    ?assert(about_lists:lists_are_not_homogeneous()).
 
 we_can_add_test() ->
     ?assertEqual([apple, banana, mango, orange], about_lists:we_can_add()).


### PR DESCRIPTION
Thanks for the koans! Noticed this spelling mistake and changed it. Ran `escript koans test` and it worked!